### PR TITLE
bpo-31485: Fix Misc.unbind behaviour when funcid is given

### DIFF
--- a/Lib/tkinter/__init__.py
+++ b/Lib/tkinter/__init__.py
@@ -1385,11 +1385,14 @@ class Misc:
         return self._bind(('bind', self._w), sequence, func, add)
 
     def unbind(self, sequence, funcid=None):
-        """Unbind for this widget for event SEQUENCE  the
-        function identified with FUNCID."""
-        self.tk.call('bind', self._w, sequence, '')
+        """Unbind for this widget the event SEQUENCE. if
+        FUNCID is given, delete the command also."""
+        bound = ''
         if funcid:
             self.deletecommand(funcid)
+            funcs = self.tk.call('bind', self._w, sequence, None).split('\n')
+            bound = '\n'.join([f for f in funcs if not f.startswith(f'if {{"[{funcid}')])
+        self.tk.call('bind', self._w, sequence, bound)
 
     def bind_all(self, sequence=None, func=None, add=None):
         """Bind to all widgets at an event SEQUENCE a call to function FUNC.


### PR DESCRIPTION
Allows Misc.unbind to delete only the bound callback having the given funcid. 
See https://bugs.python.org/issue31485 for furtherdetails.

<!--
Thanks for your contribution!
Please read this comment in its entirety. It's quite important.

# Pull Request title

It should be in the following format:

```
bpo-NNNN: Summary of the changes made
```

Where: bpo-NNNN refers to the issue number in the https://bugs.python.org.

Most PRs will require an issue number. Trivial changes, like fixing a typo, do not need an issue.

# Backport Pull Request title

If this is a backport PR (PR made against branches other than `master`),
please ensure that the PR title is in the following format:

```
[X.Y] <title from the original PR> (GH-NNNN)
```

Where: [X.Y] is the branch name, e.g. [3.6].

GH-NNNN refers to the PR number from `master`.

-->
